### PR TITLE
Added proper target definition, which only uses p2 update sites

### DIFF
--- a/releng/org.locationtech.geoff.releng.target/geoff.target
+++ b/releng/org.locationtech.geoff.releng.target/geoff.target
@@ -1,10 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="geoff" sequenceNumber="1409144004">
+<?pde version="3.8"?><target name="geoff" sequenceNumber="1409144007">
 <locations>
-<location path="${eclipse_home}" type="Profile"/>
 <location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
 <unit id="org.json" version="1.0.0.v201011060100"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20130827064939/repository/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.sdk.ide" version="4.5.2.M20160212-1500"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.5"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="slicer" includeSource="true" type="InstallableUnit">
+<unit id="org.eclipse.emf.sdk.feature.group" version="2.11.2.v20160208-0841"/>
+<repository location="http://download.eclipse.org/releases/mars/"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
Hi Erdal,

I've seen your mail concerning the properties page on the e4-dev-mailinglist and have some idea's about it.
First of all I'd like to have a proper target definition for your project, since I had some compile errors due to missing dependencies and a target definition pointing to the installation doesn't really help. 
