### PR TITLE
Subscribe UILifeCycle.ACTIVATE rather than attaching a part listener manually

### DIFF
--- a/plugins/org.locationtech.geoff.ui/src/org/locationtech/geoff/ui/internal/PageBookFunction.java
+++ b/plugins/org.locationtech.geoff.ui/src/org/locationtech/geoff/ui/internal/PageBookFunction.java
@@ -11,11 +11,9 @@
 package org.locationtech.geoff.ui.internal;
 
 import org.eclipse.e4.core.contexts.ContextFunction;
+import org.eclipse.e4.core.contexts.ContextInjectionFactory;
 import org.eclipse.e4.core.contexts.IContextFunction;
 import org.eclipse.e4.core.contexts.IEclipseContext;
-import org.eclipse.e4.ui.model.application.ui.basic.MPart;
-import org.eclipse.swt.layout.FillLayout;
-import org.eclipse.swt.widgets.Composite;
 import org.locationtech.geoff.ui.PageBook;
 import org.osgi.service.component.annotations.Component;
 
@@ -24,10 +22,7 @@ public class PageBookFunction extends ContextFunction {
 
 	@Override
 	public Object compute(IEclipseContext context, String contextKey) {
-		Composite parent = context.get(Composite.class);
-		parent.setLayout(new FillLayout());
-		MPart hostPart = context.get(MPart.class);
-		PageBook pageBook = new E4PageBookSWTImpl(parent, context, hostPart);
+		PageBook pageBook = ContextInjectionFactory.make(E4PageBookSWTImpl.class, context);
 		return pageBook;
 	}
 


### PR DESCRIPTION
- Avoid attaching part listener manually
- Make use of the ContextInjectionFactory in the IContextFunction and therefore enable the E4PageBookSWTImpl class for DI
- Have less code

@erdalkaraca can you test whether this works?

I haven't seen such a PageBook in the e4 sample app yet in order to test it.
